### PR TITLE
Fixes imageURLs for images within links

### DIFF
--- a/Sources/CommonMark/Core/Node.swift
+++ b/Sources/CommonMark/Core/Node.swift
@@ -47,7 +47,7 @@ class Node {
         switch type {
         case CMARK_NODE_DOCUMENT, CMARK_NODE_BLOCK_QUOTE, CMARK_NODE_LIST,
              CMARK_NODE_ITEM, CMARK_NODE_PARAGRAPH, CMARK_NODE_HEADING,
-             CMARK_NODE_EMPH, CMARK_NODE_STRONG:
+             CMARK_NODE_EMPH, CMARK_NODE_STRONG, CMARK_NODE_LINK:
             return Array(children.map(\.imageURLs).joined())
         case CMARK_NODE_IMAGE:
             return [url].compactMap { $0 }

--- a/Tests/CommonMarkTests/DocumentTests.swift
+++ b/Tests/CommonMarkTests/DocumentTests.swift
@@ -456,6 +456,7 @@ final class DocumentTests: XCTestCase {
         ---
         Emphasis *![](image5.jpg)* and strong **![](image6.jpg)**\
         Repeated ![](image3.jpg)
+        [![](image7.jpg)](https://example.com)
         """
 
         // when
@@ -466,6 +467,7 @@ final class DocumentTests: XCTestCase {
             [
                 "image1.jpg", "image2.jpg", "image3.jpg",
                 "image4.jpg", "image5.jpg", "image6.jpg",
+                "image7.jpg",
             ],
             result
         )


### PR DESCRIPTION
While testing out MarkdownUI I noticed that some images weren't loading -
Did some investigation and figured out that the "link" parent node was just missing from the `imageURLs` switch.

Added the missing case and updated the test.